### PR TITLE
Handle typing text as children

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v0.3.0 (6/11/2016)
+
+* Handle typing text as children instead of a prop passed into the component
+
 ## v0.2.0 (5/26/2016)
 
 * Changing `props.text` forces the component to reset visible text and type from left to right

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ import TypeWriter from 'react-native-typewriter'
 
 class TypingText extends Component {
   render() {
-    return <TypeWriter text="Hello World!" typing={1} />
+    return <TypeWriter typing={1}>Hello World!</TypeWriter>
   }
 }
 ```
@@ -29,14 +29,6 @@ class TypingText extends Component {
 ## Documentation
 
 Any props accepted by React Native's `Text` component are accepted by `TypeWriter`. These additional props are also accepted:
-
-### text
-
-type: `String` default: `''`
-
-Text to which the component will apply animation.
-
-If `props.text` is changed, the text will restart printing from left to right.
 
 ### typing
 

--- a/index.js
+++ b/index.js
@@ -10,12 +10,12 @@ const MAX_DELAY = 100
 const TYPING_VALS = [-1, 0, 1]
 const INITIAL_STATE = { visibleChars: 0 }
 
-function isEqual(current, next) {
+function isEqual (current, next) {
   return current === next
 }
 
 export default class TypeWriter extends Component {
-  constructor(props) {
+  constructor (props) {
     super(props)
 
     this.state = INITIAL_STATE
@@ -23,54 +23,52 @@ export default class TypeWriter extends Component {
     this._setNextState = this._setNextState.bind(this)
   }
 
-  componentDidMount() {
+  componentDidMount () {
     this._start()
   }
 
-  componentWillUnmount() {
+  componentWillUnmount () {
     this._clearTimeout()
   }
 
-  componentWillReceiveProps(nextProps) {
+  componentWillReceiveProps (nextProps) {
     const active = this.props.typing
-    const next   = nextProps.typing
+    const next = nextProps.typing
 
     if (next === 0) {
       this._clearTimeout()
     } else if (!isEqual(active, next)) {
       this._setNextState(next)
-    } else if (!isEqual(nextProps.text, this.props.text)) {
+    } else if (!isEqual(nextProps.children, this.props.children)) {
       this.setState(INITIAL_STATE)
       this._start()
     }
   }
 
-  shouldComponentUpdate(nextProps, nextState) {
+  shouldComponentUpdate (nextProps, nextState) {
     return (
       !isEqual(this.state.visibleChars, nextState.visibleChars) ||
-      !isEqual(this.props.text, nextProps.text)
+      !isEqual(this.props.children, nextProps.children)
     )
   }
 
-  componentDidUpdate(prevProps, prevState) {
+  componentDidUpdate (prevProps, prevState) {
     const {
-      text,
-      maxDelay,
-      minDelay,
+      children,
       delayMap,
       onTyped,
       onTypingEnd
     } = this.props
     const {visibleChars} = prevState
-    const currentToken   = text[visibleChars]
-    const nextToken      = text[this.state.visibleChars]
+    const currentToken = children[visibleChars]
+    const nextToken = children[this.state.visibleChars]
 
     if (currentToken && onTyped) {
       onTyped(currentToken, visibleChars)
     }
 
     if (nextToken) {
-      let timeout = Math.round(Math.random() * (maxDelay - minDelay) + minDelay)
+      let timeout = this._getRandomTimeout()
 
       if (delayMap) {
         delayMap.forEach(({at, delay}) => {
@@ -86,26 +84,36 @@ export default class TypeWriter extends Component {
     }
   }
 
-  render() {
-    const {text, ...props} = this.props
+  render () {
+    const {children, ...props} = this.props
     const {visibleChars} = this.state
 
-    return <Text {...props}>{text.slice(0, visibleChars)}</Text>
+    return (
+      <Text {...props}>
+        {children.slice(0, visibleChars)}
+      </Text>
+    )
   }
 
-  _start(timeout = this.props.initialDelay) {
+  _start (timeout = this.props.initialDelay) {
     this._clearTimeout()
     this._timeoutId = setTimeout(this._setNextState, timeout)
   }
 
-  _clearTimeout() {
+  _clearTimeout () {
     if (this._timeoutId) {
       clearTimeout(this._timeoutId)
     }
   }
 
-  _setNextState(typing = this.props.typing) {
+  _setNextState (typing = this.props.typing) {
     this.setState({ visibleChars: this.state.visibleChars + typing })
+  }
+
+  _getRandomTimeout () {
+    const {maxDelay, minDelay} = this.props
+
+    return Math.round(Math.random() * (maxDelay - minDelay) + minDelay)
   }
 }
 
@@ -119,20 +127,19 @@ const delayShape = PropTypes.shape({
 })
 
 TypeWriter.propTypes = {
-  text:         PropTypes.string.isRequired,
-  typing:       PropTypes.oneOf(TYPING_VALS),
-  maxDelay:     PropTypes.number,
-  minDelay:     PropTypes.number,
+  children: PropTypes.string.isRequired,
+  typing: PropTypes.oneOf(TYPING_VALS),
+  maxDelay: PropTypes.number,
+  minDelay: PropTypes.number,
   initialDelay: PropTypes.number,
-  delayMap:     PropTypes.arrayOf(delayShape),
-  onTyped:      PropTypes.func,
-  onTypingEnd:  PropTypes.func
+  delayMap: PropTypes.arrayOf(delayShape),
+  onTyped: PropTypes.func,
+  onTypingEnd: PropTypes.func
 }
 
 TypeWriter.defaultProps = {
-  text:         '',
   initialDelay: MAX_DELAY * 2,
-  maxDelay:     MAX_DELAY,
-  minDelay:     MAX_DELAY / 5,
-  typing:       TYPING_VALS[1]
+  maxDelay: MAX_DELAY,
+  minDelay: MAX_DELAY / 5,
+  typing: TYPING_VALS[1]
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-typewriter",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "A React Native component for creating typing effects",
   "main": "index.js",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -22,5 +22,11 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/TaylorBriggs/react-native-typewriter.git"
+  },
+  "devDependencies": {
+    "standard": "*"
+  },
+  "scripts": {
+    "lint": "standard"
   }
 }


### PR DESCRIPTION
Removes the `text` prop from the component and requires typing text to be passed as children instead.
