### PR TITLE
FIX: Plugin crashes if `fixed` is set to true and `style` is set to undefined

### DIFF
--- a/index.js
+++ b/index.js
@@ -149,7 +149,7 @@ class TypeWriter extends Component {
       components.push(
         <Text
           {...props}
-          style={[...props.style, invisibleStyle]}
+          style={[...(props.style || {}), invisibleStyle]}
           key="invisible-string"
         >
           {invisibleString}


### PR DESCRIPTION
I spotted this bug when setting the `fixed` property without a style prop on the component.

p.s. Great plugin other than this bug!