### PR TITLE
Import PropTypes form separate package

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import { Text } from 'react-native';
 
 const delayShape = PropTypes.shape({

--- a/package.json
+++ b/package.json
@@ -22,6 +22,9 @@
     "Peter Mikitsh <peter.mikitsh@gmail.com>",
     "maxkomarychev (https://github.com/maxkomarychev)"
   ],
+  "dependencies": {
+    "prop-types": "^15.5.7"
+  },
   "peerDependencies": {
     "react": "15.x",
     "react-native": "^0.42.0"


### PR DESCRIPTION
Importing PropTypes from react has been deprecated since quite long and now (in RN 0.49) makes an app to crash.