### PR TITLE
Do not spread styles prop

### DIFF
--- a/index.js
+++ b/index.js
@@ -151,7 +151,7 @@ class TypeWriter extends Component {
       components.push(
         <Text
           {...props}
-          style={[...props.style, invisibleStyle]}
+          style={[props.style, invisibleStyle]}
           key="invisible-string"
         >
           {invisibleString}


### PR DESCRIPTION
After upgrading to React Native 0.57 I get following error.

<img width="338" alt="screenshot 2018-12-14 at 08 35 47" src="https://user-images.githubusercontent.com/117428/49989684-5d872b80-ff7b-11e8-95e3-271ba1c91c11.png">

I noticed it's caused by `[...props.style, invisibleStyle]` line. It's not really needed to use spread operator here if styles definitions are provided in array.