### PR TITLE
Added the ability for text to start in a typed out.

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,12 @@ type: `Number` default: `0`
 A value of 1 types text left to right until completion. A value of -1 erases
 text from right to left. A value of 0 stops the animation.
 
+### startTyped
+
+type: `Boolean` default: `false`
+
+A true value will make the value typed out when the component renders, this is useful when one wants to show a static value and change to a different value making the latter being typed out.
+
 ### fixed
 
 type: `Boolean` default: `false`

--- a/components/typewriter.js
+++ b/components/typewriter.js
@@ -8,6 +8,7 @@ const MAX_DELAY = 100;
 
 export default class TypeWriter extends Component {
   static propTypes = {
+    startTyped: PropTypes.bool,
     children: PropTypes.node.isRequired,
     delayMap: PropTypes.arrayOf(
       PropTypes.shape({
@@ -33,6 +34,7 @@ export default class TypeWriter extends Component {
   };
 
   static defaultProps = {
+    startTyped: false,
     fixed: false,
     initialDelay: MAX_DELAY * 2,
     maxDelay: MAX_DELAY,
@@ -150,6 +152,7 @@ export default class TypeWriter extends Component {
 
   render() {
     const {
+      startTyped,
       children,
       delayMap,
       fixed,
@@ -167,6 +170,10 @@ export default class TypeWriter extends Component {
         {children}
       </Text>
     );
+
+    if(startTyped){
+    return component
+    }
 
     return hideSubstring(component, fixed, visibleChars);
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-typewriter",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "A React Native component for creating typing effects",
   "main": "index.js",
   "license": "MIT",


### PR DESCRIPTION
An example of how this prop can be used is the following, used in react-native to switch to "Number copied to clipboard"  text being typed out when copying.

```
    <TypeWriter
            startTyped={copied ? false : true}
            fixed
            minDelay={10}
            maxDelay={10}
            typing={copied ? 1 : 0}
            onTypingEnd={async () => {
              await sleep(1500)
              this.setState({
                copied: false
              })
            }}
          >
            <Text titleBlue={copied} bold primary size={11}>
              {copied ? "Number copied to clipboard" : item.description}
            </Text>
          </TypeWriter>
```