### PR TITLE
Get rid of error when "typing" prop is set to > 1

### DIFF
--- a/components/typewriter.js
+++ b/components/typewriter.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { Text } from 'react-native';
 import { getTokenAt, hideSubstring } from '../utils';
 
-const DIRECTIONS = [-1, 0, 1];
+const DIRECTIONS = [-1, 0, 10];
 const MAX_DELAY = 100;
 
 export default class TypeWriter extends Component {


### PR DESCRIPTION
For my app, I needed the type speed to be a little faster... please consider my one character proposal and thank you for creating this library